### PR TITLE
Fix search problem with duplicate module names

### DIFF
--- a/src/components/AccreditedModulesModal.vue
+++ b/src/components/AccreditedModulesModal.vue
@@ -49,7 +49,7 @@
                       <ModuleSearch
                         :button-width-class="'w-16'"
                         :show-next-possible-semester="false"
-                        @on-module-selected="moduleName => onModuleSelected(moduleName)"
+                        @on-module-selected="moduleId => onModuleSelected(moduleId)"
                       />
                     </div>
                     <div>
@@ -250,8 +250,8 @@ export default defineComponent({
     closeModal() {
       this.modalIsOpen = false;
     },
-    onModuleSelected(moduleName: string) {
-      const module = store.getters.modules.find(m => m.name === moduleName);
+    onModuleSelected(moduleId: string) {
+      const module = store.getters.modules.find(m => m.id === moduleId);
       if(module) {
         this.selectedModules.push(module);
       }

--- a/src/components/Categories.vue
+++ b/src/components/Categories.vue
@@ -22,7 +22,7 @@
               :category-id="category.id"
               :show-next-possible-semester="true"
               :button-width-class="'w-10'"
-              @on-module-selected="(name: string) => addModule(name)"
+              @on-module-selected="(moduleId) => addModule(moduleId)"
             />
           </div>
         </td>
@@ -58,8 +58,8 @@ export default defineComponent({
     ...mapGetters(['enrichedCategories', 'totalPlannedEcts', 'totalEarnedEcts']),
   },
   methods: {
-    addModule(name: string) {
-      this.$emit('on-add-module', name);
+    addModule(moduleId: string) {
+      this.$emit('on-add-module', moduleId);
     },
   },
 });

--- a/src/components/Focus.vue
+++ b/src/components/Focus.vue
@@ -47,7 +47,7 @@
           v-if="!!module.nextPossibleSemester"
           class="bg-gray-800 text-white text-xs mx-2 px-2 py-1 rounded"
           type="button"
-          @click="$emit('on-add-module-to-next-sem', module.name)"
+          @click="$emit('on-add-module-to-next-sem', module.id)"
         >
           + {{ module.nextPossibleSemester.toString() }}
         </button>

--- a/src/components/ModuleSearch.vue
+++ b/src/components/ModuleSearch.vue
@@ -66,7 +66,7 @@
             v-for="module in filteredModulesByGroup(group.id)"
             v-show="group.isOpen"
             :key="module.id"
-            :value="module.name"
+            :value="module.id"
             as="template"
             :disabled="moduleIsDisabled(module)"
           >
@@ -192,10 +192,10 @@ export default defineComponent({
       }
       return false;
     },
-    selectModule(moduleName: string) {
-      if (moduleName) {
+    selectModule(moduleId: string) {
+      if (moduleId) {
         // can be null, if Combobox is closed through blur
-        this.$emit('on-module-selected', moduleName);
+        this.$emit('on-module-selected', moduleId);
       }
       this.isSearching = false;
     },

--- a/src/components/ModuleSearch.vue
+++ b/src/components/ModuleSearch.vue
@@ -209,7 +209,13 @@ export default defineComponent({
         });
         const modulesInGroups = groups.flatMap(g => g.modules).map(m => m.id);
         const modulesNotInGroups = store.getters.modules.filter(m => !modulesInGroups.includes(m.id));
-        this.groupedModules =  groups.concat({ id: 'none', name: 'Ohne', modules: modulesNotInGroups, isOpen: this.categoryId ? false : true, colorClass: getColorClassForCategoryId('') });
+        this.groupedModules =  groups.concat({
+          id: 'none',
+          name: 'Ohne',
+          modules: modulesNotInGroups,
+          isOpen: this.categoryId ? false : true,
+          colorClass: getColorClassForCategoryId('')
+        });
       }
       this.query = '';
       this.isSearching = true;

--- a/src/components/ModuleSearch.vue
+++ b/src/components/ModuleSearch.vue
@@ -50,12 +50,12 @@
         >
           <div
             class="hover:cursor-pointer px-2 text-white flex justify-between items-center"
-            :class="group.colorClassObject"
+            :class="group.colorClass"
             :aria-expanded="group.isOpen"
             type="button"
             @click="toggleGroup(group.id)"
           >
-            <span>{{ group.id }}</span>
+            <span>{{ group.name }}</span>
             <font-awesome-icon
               :icon="['fa', group.isOpen ? 'chevron-up' : 'chevron-down']"
               class="h-5 w-5 ml-2"
@@ -87,7 +87,7 @@
                 >
                   geplant
                 </span>
-                <span v-else-if="module.isDeactivated && disableBasedOnTerm">
+                <span v-else-if="module.isDeactivated && disableInvalidModules">
                   inaktiv
                 </span>
                 <span v-else>
@@ -99,7 +99,7 @@
                 <span v-if="showNextPossibleSemester && module.nextPossibleSemester">
                   ({{ module.nextPossibleSemester }})
                 </span>
-                <span v-else-if="moduleHasWrongTerm(module) && disableBasedOnTerm">
+                <span v-else-if="moduleHasWrongTerm(module) && disableInvalidModules">
                   nur im {{ module.term }}
                 </span>
                 <span v-else>
@@ -127,7 +127,7 @@ import {
   } from '@headlessui/vue';
 import { getColorClassForCategoryId } from '../helpers/color-helper';
 
-export type GroupedModule = {id: string, name: string, modules: Module[], isOpen: boolean, colorClassObject: object };
+export type GroupedModule = {id: string, name: string, modules: Module[], isOpen: boolean, colorClass: object };
 
 export default defineComponent({
   name: 'ModuleSearch',
@@ -158,7 +158,7 @@ export default defineComponent({
       required: false,
       default: 'both'
     },
-    disableBasedOnTerm: {
+    disableInvalidModules: {
       type: Boolean,
       required: false,
       default: true,
@@ -176,17 +176,14 @@ export default defineComponent({
   },
   methods: {
     moduleIsDisabled(module: Module): boolean {
-      return this.moduleIsInPlan(module) ||
+      return this.moduleIsInPlan(module) || (this.disableInvalidModules && (
         this.moduleHasWrongTerm(module) ||
-        (this.showNextPossibleSemester && !module.nextPossibleSemester);
+        (this.showNextPossibleSemester && !module.nextPossibleSemester)));
     },
     moduleIsInPlan(module: Module): boolean {
       return store.getters.allPlannedModuleIds.includes(module.id);
     },
     moduleHasWrongTerm(module: Module): boolean {
-      if (!this.disableBasedOnTerm) {
-        return false;
-      }
       if (this.termForWhichToSearch !== 'both' && module.term !== 'both') {
         return this.termForWhichToSearch !== module.term;
       }
@@ -201,17 +198,18 @@ export default defineComponent({
     },
     startSearching() {
       if(!this.isSearching) {
-        this.groupedModules = store.getters.enrichedCategories.map(c => {
-          const colorClassObject = {};
-          colorClassObject[getColorClassForCategoryId(c.id)] = true;
+        const groups = store.getters.enrichedCategories.map(c => {
           return {
             id: c.id,
             name: c.name,
             modules: c.modules,
             isOpen: this.categoryId ? this.categoryId === c.id : true,
-            colorClassObject
+            colorClass: getColorClassForCategoryId(c.id),
           };
         });
+        const modulesInGroups = groups.flatMap(g => g.modules).map(m => m.id);
+        const modulesNotInGroups = store.getters.modules.filter(m => !modulesInGroups.includes(m.id));
+        this.groupedModules =  groups.concat({ id: 'none', name: 'Ohne', modules: modulesNotInGroups, isOpen: this.categoryId ? false : true, colorClass: getColorClassForCategoryId('') });
       }
       this.query = '';
       this.isSearching = true;

--- a/src/components/Semester.vue
+++ b/src/components/Semester.vue
@@ -42,7 +42,7 @@
         :container-bound="true"
         :term-for-which-to-search="term"
         :disable-based-on-term="!isInPast"
-        @on-module-selected="(name: string) => addModule(name)"
+        @on-module-selected="(moduleId) => addModule(moduleId)"
       />
       <div class="mt-auto p-2">
         <p>{{ getTotalEcts }} ECTS</p>
@@ -97,8 +97,8 @@ export default defineComponent({
     }
   },
   methods: {
-    addModule(name: string) {
-      this.$emit('on-add-module', name, this.semester.number);
+    addModule(moduleId: string) {
+      this.$emit('on-add-module', moduleId, this.semester.number);
     },
     removeSemester() {
       this.$emit('on-remove-semester', this.semester.number);

--- a/src/components/Semester.vue
+++ b/src/components/Semester.vue
@@ -41,7 +41,7 @@
         :list-width-class="'w-64'"
         :container-bound="true"
         :term-for-which-to-search="term"
-        :disable-based-on-term="!isInPast"
+        :disable-invalid-modules="!isInPast"
         @on-module-selected="(moduleId) => addModule(moduleId)"
       />
       <div class="mt-auto p-2">

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -218,30 +218,30 @@ export default defineComponent({
     updateUrlFragment() {
       StorageHelper.updateUrlFragment();
     },
-    getPlannedSemesterForModule(moduleName: string): number | undefined {
+    getPlannedSemesterForModule(moduleId: string): number | undefined {
       return this.enrichedSemesters.find(
-        (semester) => semester.modules.some((module) => module.name === moduleName),
+        (semester) => semester.modules.some((module) => module.id === moduleId),
       )?.number;
     },
-    addModule(moduleName: string, semesterNumber?: number) {
-      const blockingSemesterNumber = this.getPlannedSemesterForModule(moduleName);
+    addModule(moduleId: string, semesterNumber?: number) {
+      const module = this.modules.find((item) => item.id === moduleId);
+
+      if (module === undefined) {
+        this.showErrorMsg(`Modul '${moduleId}' existiert nicht`);
+        return;
+      }
+
+      const blockingSemesterNumber = this.getPlannedSemesterForModule(moduleId);
       if (blockingSemesterNumber) {
-        const text = `Modul ${moduleName} ist bereits im Semester ${blockingSemesterNumber}`;
+        const text = `Modul ${module.name} ist bereits im Semester ${blockingSemesterNumber}`;
         console.warn(text);
         this.showErrorMsg(text);
         return;
       }
 
-      const module = this.modules.find((item) => item.name === moduleName);
-
-      if (module === undefined) {
-        this.showErrorMsg(`Modul '${moduleName}' existiert nicht`);
-        return;
-      }
-
       if(!semesterNumber) {
         if(!module.nextPossibleSemester) {
-          this.showErrorMsg(`Kein nächstmögliches Semester für Modul ${moduleName} gefunden`);
+          this.showErrorMsg(`Kein nächstmögliches Semester für Modul ${module.name} gefunden`);
           return;
         }
         let nextSemester = this.enrichedSemesters.find(s => s.name === module.nextPossibleSemester.toString())
@@ -252,7 +252,7 @@ export default defineComponent({
         semesterNumber = nextSemester.number;
       }
 
-      store.commit('addModuleToSemester', {semesterNumber, moduleId: module.id});
+      store.commit('addModuleToSemester', {semesterNumber, moduleId: moduleId});
       this.updateUrlFragment();
     },
     removeModule(semesterNumber: number, moduleId: string) {


### PR DESCRIPTION
Trying to add a module, when another one with same name existed (e.g. Wireless and IoT) could result in the wrong one being added. We now use the id instead of the name.